### PR TITLE
Document multiplayer score submission flow

### DIFF
--- a/score-submission.md
+++ b/score-submission.md
@@ -1,5 +1,7 @@
 # Current score submission flow
 
+## Solo
+
 ```mermaid
 
 sequenceDiagram title Score submission flow
@@ -18,7 +20,7 @@ sequenceDiagram title Score submission flow
     W->>DB: Store token to solo_score_tokens
     W-->>-C: Provide {token_id} (APIScoreToken)
 
-    C->>+S: Signal begin play (BeginPlaySession({token_id}))
+    C->>+S: Signal begin play (BeginPlaySession({token_id, type: solo}))
     Note over C: Playing beatmap
 
     loop Gameplay
@@ -29,7 +31,7 @@ sequenceDiagram title Score submission flow
     C->>S: Signal finished (EndPlaySession)
 
     C->>+W: Submit score (PUT /beatmaps/{beatmap_id}/solo/scores/{token_id})
-    W->>DB: Store token to solo_scores
+    W->>DB: Store score to solo_scores
     W->>R: Push to score-statistics
     W-->>-C: Provide {score_id}
     
@@ -37,6 +39,65 @@ sequenceDiagram title Score submission flow
     
     par Replay upload
         DB-->>S: Found score_id for token (solo_score_tokens.score_id IS NOT NULL)
+        S->>S3: Upload replay (ScoreUploader.Flush)
+        S->>-DB: Mark has replay (UPDATE solo_scores SET has_replay = 1)
+    and Score processing
+        R-->>+QS: Pop queue entry from score-statistics
+        QS->>DB: Update playcount (osu_user_beatmap_playcount, osu_user_month_playcount)
+        QS->>DB: Update pp (INSERT INTO solo_scores_performance)
+        QS->>DB: Update other statistics (UPDATE osu_user_stats)
+        QS->>DB: Award medals (INSERT INTO osu_user_achievements)
+        QS->>DB: Set preserve flag if required (UPDATE solo_score SET preserve = 1)
+        QS->>-R: Push to indexing queue (score-index-{schema_version})
+    and Score indexing
+        R-->>+QE: Pop queue entry from score_index-{schema_version}
+        DB-->>QE: Read score (solo_scores)
+        QE->>-ES: Update index
+    end
+```
+
+## Multiplayer
+
+The multiplayer score submission flow is in a large part similar to the solo submission flow, except for interacting with different API endpoints, different database tables and using different ID schemes ("multiplayer link ID" rather than "solo score token ID").
+
+```mermaid
+
+sequenceDiagram title Score submission flow
+    participant C as osu!lazer
+    participant W as osu-web
+    participant S as osu-spectator-server
+    participant QS as osu-queue-score-statistics
+    participant QE as osu-elastic-indexer
+    participant DB as MySQL
+    participant R as Redis
+    participant S3
+    participant ES as Elasticsearch
+
+    C->>+W: Request room score creation (POST /rooms/{room_id}/playlist/{playlist_item_id}/scores)
+
+    W->>DB: Create new row in multiplayer_score_links
+    W-->>-C: Provide {score_link_id} (APIScoreToken)
+
+    C->>+S: Signal begin play (BeginPlaySession({score_link_id, type: multiplayer}))
+    Note over C: Playing beatmap
+
+    loop Gameplay
+        C->>S: Send frame bundle (SendFrameData)
+    end
+
+    Note over C: Finished playing
+    C->>S: Signal finished (EndPlaySession)
+
+    C->>+W: Submit score (PUT /rooms/{room_id}/playlist/{playlist_item_id}/scores/{score_link_id})
+    W->>DB: Store score to solo_scores
+    W->>DB: Associate multiplayer_score_links row with solo_scores row
+    W->>R: Push to score-statistics
+    W-->>-C: Provide {score_link_id, solo_score_id}
+    
+    # TODO: anticheat flow should probably be inserted here, redirecting to a separate queue
+    
+    par Replay upload
+        DB-->>S: Found score_id for score link (multiplayer_score_links.score_id IS NOT NULL)
         S->>S3: Upload replay (ScoreUploader.Flush)
         S->>-DB: Mark has replay (UPDATE solo_scores SET has_replay = 1)
     and Score processing


### PR DESCRIPTION
This PR adds documentation about the multiplayer score submission flow in the form of a sequence diagram. It was primarily created by taking the existing solo score submission flow sequence diagram and adapting it to the differences specific to the multi flow (different endpoints, different tables, different ID schemes).

This diagram does not describe the current state of things. It describes where things _should_ be after a sequence of some already-PRed changes such as:

- https://github.com/ppy/osu-web/pull/10437
- https://github.com/ppy/osu/pull/24697
- https://github.com/ppy/osu-server-spectator/pull/185

and some changes that are still being worked on (primarily client-side at this point).

The main goal of the document is to inform the changes above. (And to be something that I can easily refer to, because I keep looking up the same information over and over right now.)

@nanaya this is something you may want to look over to make sure I haven't misconstrued anything on the web side.